### PR TITLE
Add Python CICD fixes and rollback handling to server.py

### DIFF
--- a/server.py
+++ b/server.py
@@ -229,8 +229,7 @@ def handle_deploy(repo_cfg: RepoConfig, payload: dict, is_dev: bool):
 
     # Docker Compose
     status.docker_execution_result = run_command(
-        # ["docker-compose", "up", "--build", "-d"], repo_cfg.path
-        ["return", "1"], repo_cfg.path
+        ["docker-compose", "up", "--build", "-d"], repo_cfg.path
     )
 
     if not status.docker_execution_result.success:
@@ -469,16 +468,16 @@ def perform_rollback(repo_cfg: RepoConfig, backup_name: str):
     """Resets the branch to the backup and restarts the containers."""
     try:
         logger.warning(f"Rolling back {repo_cfg.name} to {backup_name}")
-        # Reset the local branch to exactly what was in the backup
+        # reset the local branch to exactly what was in the backup
         subprocess.run(["git", "reset", "--hard", backup_name], cwd=repo_cfg.path, check=True)
-        # Restart docker with the old (working) code
+        # restart docker with the old (working) code
         subprocess.run(["docker-compose", "up", "--build", "-d"], cwd=repo_cfg.path, check=True)
         return True
     except Exception:
         logger.exception(f"Rollback failed for {repo_cfg.name}:{repo_cfg.branch}")
         return False
     finally:
-        # Cleanup: Delete the backup branch after reset
+        # delete the backup branch after reset
         subprocess.run(["git", "branch", "-D", backup_name], cwd=repo_cfg.path, capture_output=True)
 
 


### PR DESCRIPTION
Add a CI/CD check function to server.py
Steps on how to test:

1. Run the server using **"python3 server.py"**
2. Ensure that config.yml includes your repo, branch, and path.
My example: 
repos:
  - name: sce-cicd
    branch: main
    path: /Users/Brian/sce-cicd
    force_recreate: false
3. Triggered a webhook event using a **curl command**
Ex:
curl command to test deployment successful:
curl -X POST \
  -H "Content-Type: application/json" \
  -H "X-GitHub-Event: push" \
  --data '{
    "ref": "refs/heads/main",
    "repository": {"name": "sce-cicd"},
    "head_commit": {
      "id": "abc123def456",
      "message": "Deployment successful test commit",
      "branch": "main",
      "url": "https://github.com/SCE-Development/sce-cicd/commit/abc123def456",
      "author": {"name": "Test User", "username": "testuser", "url": "https://github.com/testuser"}
    }
  }' \
  http://127.0.0.1:3000/webhook
curl command to test rollback:
curl -X POST \
  -H "Content-Type: application/json" \
  -H "X-GitHub-Event: push" \
  --data '{
    "ref": "refs/heads/main",
    "repository": {"name": "sce-cicd"},
    "head_commit": {
      "id": "abc123def456",
      "message": "Test commit",
      "branch": "main",
      "url": "https://github.com/SCE-Development/sce-cicd/commit/abc123def456",
      "author": {"name": "Test User", "username": "testuser", "url": "https://github.com/testuser"}
    }
  }' \
  http://127.0.0.1:3000/webhook
  
  4. **Terminal Output:**
  You should see logs indicating that a push was detected. If docker-compose fails a rollback log message will appear in the terminal like this:
"  ROLLBACK INITIATED
docker-compose failed (exit code ...), git pull exit code .... Rollback would be performed here (mocked in dev).
Rollback skipped for local development. No destructive git reset performed.
ROLLBACK COMPLETE"

5. If your discord webhook is set up, you will see a deployment status embed in your Discord channel. To create a webhook to test the embed, follow this tutorial: https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks

**Output**:
The first screenshot shows when a commit is sucessful. The second screenshot shows when a commit is failed and invalid, which proceeds to run the rollback command:
<img width="968" height="1174" alt="image" src="https://github.com/user-attachments/assets/cdaef3ea-02cc-49e9-b158-7e6736de2b0a" />
<img width="942" height="1340" alt="image" src="https://github.com/user-attachments/assets/c3787790-b21a-4809-b463-11fb96175d2f" />

  