### PR TITLE
Add Prometheus metric for Docker image disk usage

### DIFF
--- a/server.py
+++ b/server.py
@@ -131,7 +131,7 @@ def get_docker_images_disk_usage_bytes():
     try:
         cmd = [
             "sh", "-c",
-            "docker images --format '{{.Size}}' | awk '/GB/ {gsub(\"GB\",\"\"); sum+=($1*1024*1024*1024)} /MB/ {gsub(\"MB\",\"\"); sum+=($1*1024*1024)} /kB/ {gsub(\"kB\",\"\"); sum+=($1*1024)} END {print sum}'"
+            'docker images --format "{{.Size}}" | awk \'/GB/ {gsub("GB", ""); sum+=($1*1024*1024*1024)} /MB/ {gsub("MB", ""); sum+=($1*1024*1024)} /kB/ {gsub("kB", ""); sum+=($1*1024)} END {print int(sum)}\''
         ]
         result = subprocess.run(cmd, capture_output=True, text=True, check=True)
         output = result.stdout.strip()


### PR DESCRIPTION
Added a Prometheus metric that reports the total disk usage of all Docker images on the host. This helps allow to track Docker image storageusage over time in the monitoring dashbaords. 
To test this:
1. Activate virtual environment `source .venv/bin/activate`
2. instal dependencies: `pip install -r requirements.txt` 
3. run the FastAPI server: `uvicorn server:app --port 3000 --reload`
4. check metrics endpoint using [http://127.0.0.1:3000/metrics](http://127.0.0.1:3000/metrics)
5. Look for a line that says "docker_image_disk_usage_bytes <number>"
Example: 
<img width="1506" height="958" alt="image" src="https://github.com/user-attachments/assets/cf3a3677-5578-485b-bc0c-ee0c08c0a7ed" />
